### PR TITLE
Add explicit git pull reconciliation strategy

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -32,3 +32,5 @@
 	tree2 = log --graph --abbrev-commit --decorate --format=format:'%C(bold red)%h%C(reset) - %C(bold green)%s%C(reset) %C(bold blue)(%ar)%C(reset)%C(bold red)%d%C(reset)%n''%C(dim white){ Author: %C(reset)%C(white)%an%C(dim white), Email: %C(reset)%C(white)%ae%C(dim white), Updated at: %C(reset)%C(white)%cd%C(dim white) }%C(reset)' --all
 	tr = !"git tree2"
 	s = status
+[pull]
+	ff = only

--- a/git/git-pull-local-repositories.sh
+++ b/git/git-pull-local-repositories.sh
@@ -14,6 +14,7 @@ pull_git_repositories()
     echo $BREAKER
     echo $(date) "==> Updating git repository '${bold}$GIT_REPO${normal}'"
     cd $GIT_REPO
+    git checkout master
     git pull
     cd ..
     echo "\n\n" $(date) "${bold}==> ${GREEN}[OK]${RST} Finished pulling git repository"


### PR DESCRIPTION
In order to resolve the git warning:

```
Pulling without specifying how to reconcile divergent branches is discouraged. You can squelch this message by running one of the following commands sometime before your next pull.
```

The following global git configuration was added:

```
git config pull.ff only       # fast-forward only
```